### PR TITLE
Align with metaproxy/etc/cql2pqf.txt

### DIFF
--- a/bibframe/cql2pqf.txt
+++ b/bibframe/cql2pqf.txt
@@ -8,9 +8,10 @@
 # XSLT transformation 'explain2cqlpqftxt.xsl'
 #
 # xsltproc explain2cqlpqftxt.xsl explain.xml
-    
+
 
 # Based on metaproxy/etc/cql2pqf.txt
+# Here bf.* mapping is added.
 
 # Set info
 # Default set
@@ -22,6 +23,7 @@ set.dc = info:srw/cql-context-set/1/dc-v1.1
 set.bib1 = 1.2.840.10003.3.1
 
 # Index info
+index.bf.* = 1=bf.*
 index.cql.serverChoice = 1=1010 
 index.cql.all = 1=1010 
 index.rec.id = 1=12

--- a/bibframe/cql2pqf.txt
+++ b/bibframe/cql2pqf.txt
@@ -1,5 +1,5 @@
 
-# Propeties file to drive org.z3950.zing.cql.CQLNode's toPQF()
+# Properties file to drive org.z3950.zing.cql.CQLNode's toPQF()
 # back-end and the YAZ CQL-to-PQF converter.  This specifies the
 # interpretation of various CQL indexes, relations, etc. in terms
 # of Type-1 query attributes.
@@ -7,10 +7,10 @@
 # This file is created from a valid ZeeRex Explain XML record using the 
 # XSLT transformation 'explain2cqlpqftxt.xsl'
 #
-# xsltproc explain2cqlpqf.xsl explain.xml
+# xsltproc explain2cqlpqftxt.xsl explain.xml
     
 
-# Title: Metaproxy SRU explain record
+# Based on metaproxy/etc/cql2pqf.txt
 
 # Set info
 # Default set
@@ -56,7 +56,7 @@ position.last                           = 3=4 6=1
 position.firstAndLast                   = 3=3 6=3
 
 # Structure attributes may be specified for individual relations; a
-# default structure attribute my be specified by the pseudo-relation
+# default structure attribute may be specified by the pseudo-relation
 # "*", to be used whenever a relation not listed here occurs.
 #
 structure.exact                         = 4=108

--- a/bibframe/cql2pqf.txt
+++ b/bibframe/cql2pqf.txt
@@ -27,7 +27,7 @@ index.cql.all = 1=1010
 index.rec.id = 1=12
 index.dc.title = 1=4 
 index.dc.creator = 1=1003 
-index.dc.subject = 1=47 
+index.dc.subject = 1=21 
 index.dc.description = 1=62 
 index.dc.publisher = 1=1018 
 index.dc.contributor = 1=1003 


### PR DESCRIPTION
Fixing inconsistencies between these configuration files. There are some others that i wonder about:

The main metaproxy config has:
  index.rec.id = 1=12 4=3
whereas mp-xquery and mp-sparql (and yaz) have:
  index.rec.id = 1=12

The main metaproxy config and mp-xquery have:
  index.cql.serverChoice = 1=1010
  index.cql.all = 1=1010
whereas mp-sparql (and yaz) have:
  index.cql.serverChoice = 1=1016
  index.cql.all = 1=1016

The latter seems to be correct in each case.
